### PR TITLE
add cancan and setup three access levels

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg'
 gem 'dotenv-rails'
 gem 'activeadmin', github: 'activeadmin'
 gem 'devise', '~> 3.2'
+gem 'cancancan', '~> 1.10'
 #gem "meta_search", '>= 1.1.0.pre'
 
 #Use for file uploads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       sass (~> 3.4)
       thor
     builder (3.2.2)
+    cancancan (1.10.1)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -273,6 +274,7 @@ PLATFORMS
 
 DEPENDENCIES
   activeadmin!
+  cancancan (~> 1.10)
   capybara
   coffee-rails (~> 4.1.0)
   database_cleaner

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register AdminUser do
-  permit_params :email, :password, :password_confirmation
+  permit_params :email, :password, :password_confirmation, :role
 
   index do
     selectable_column
@@ -21,6 +21,7 @@ ActiveAdmin.register AdminUser do
       f.input :email
       f.input :password
       f.input :password_confirmation
+      f.input :role, as: :select, :collection => ["Super", "Admin", "Publisher"]
     end
     f.actions
   end

--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -21,7 +21,9 @@ ActiveAdmin.register AdminUser do
       f.input :email
       f.input :password
       f.input :password_confirmation
-      f.input :role, as: :select, :collection => ["Super", "Admin", "Publisher"]
+      if can? :assign_roles, AdminUser.new
+        f.input :role, as: :select, :collection => ["Super", "Admin", "Publisher"]
+      end
     end
     f.actions
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,12 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def access_denied(exception)
+    redirect_to admin_organizations_path, :alert => exception.message
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_admin_user)
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -5,15 +5,16 @@ class Ability
     can :read, Feed
     can :manage, Episode
     can :read, ActiveAdmin::Page, :name => "Dashboard"
+    can :manage, AdminUser, :id => user.id
 
     if user.role == "Admin"
-      can :manage, Feed
-      can :manage, AdminUser, :id => user.id
+      can :edit, Feed
     end
 
     if user.role == "Super"
       can :manage, Feed
       can :manage, AdminUser
+      can :change_role, AdminUser
     end
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,20 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    can :read, Feed
+    can :manage, Episode
+    can :read, ActiveAdmin::Page, :name => "Dashboard"
+
+    if user.role == "Admin"
+      can :manage, Feed
+      can :manage, AdminUser, :id => user.id
+    end
+
+    if user.role == "Super"
+      can :manage, Feed
+      can :manage, AdminUser
+    end
+  end
+
+end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -62,7 +62,7 @@ ActiveAdmin.setup do |config|
   # method in a before filter of all controller actions to
   # ensure that there is a user with proper rights. You can use
   # CanCanAdapter or make your own. Please refer to documentation.
-  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+   config.authorization_adapter = ActiveAdmin::CanCanAdapter
 
   # In case you prefer Pundit over other solutions you can here pass
   # the name of default policy class. This policy will be used in every

--- a/db/migrate/20150320174246_add_role_to_admin_users.rb
+++ b/db/migrate/20150320174246_add_role_to_admin_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToAdminUsers < ActiveRecord::Migration
+  def change
+    add_column :admin_users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150318023836) do
+ActiveRecord::Schema.define(version: 20150320174246) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20150318023836) do
     t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "role",                   limit: 255
   end
 
   add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
implements the simplest version of role based security. each user is assign exactly one role: Publisher, Admin, or Super.

All: can view and change their own account details, except role
Publisher: can view feeds and manage episodes
Admin: can manage feeds in addition to above
Super: can manage users and change their roles, as well as above
