### PR TITLE
Image upload

### DIFF
--- a/app/admin/episode.rb
+++ b/app/admin/episode.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Episode do
 
-  permit_params :title, :subtitle, :summary, :url, :length, :author, :link, :is_published, :published, :published_date, :published_time_hour, :published_time_minute, :feed_id, :categories, :mp3, :image, :order, :comments_url
+  permit_params :title, :subtitle, :summary, :url, :length, :author, :link, :is_published, :published, :published_date, :published_time_hour, :published_time_minute, :feed_id, :categories, :mp3, :image, :remote_image_url, :order, :comments_url
 
   index do
     id_column
@@ -30,11 +30,15 @@ ActiveAdmin.register Episode do
         f.input :length
       end
 
+      f.inputs "Image" do
+        f.input :image, :as => :file
+        f.input :remote_image_url
+      end
+
       f.inputs "Metadata" do
         f.input :author 
         f.input :link
         f.input :categories
-        f.input :image
         f.input :order
         f.input :comments_url
       end

--- a/app/admin/episode.rb
+++ b/app/admin/episode.rb
@@ -31,7 +31,7 @@ ActiveAdmin.register Episode do
       end
 
       f.inputs "Image" do
-        f.input :image, :as => :file
+        f.input :image, :as => :file, :hint => image_tag(f.object.image_url) 
         f.input :remote_image_url
       end
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -110,8 +110,8 @@ class Episode < ActiveRecord::Base
         self.length = self.length || mp3info.tag2.TLEN
         self.summary = self.summary || mp3info.tag2.COMM
 
-        if mp3info.tag2.pictures.first
-          self.image = self.image || StringIO.new(mp3info.tag2.pictures.first.last)
+        if mp3info.tag2.pictures.first && !self.image.size
+          self.image = StringIO.new(mp3info.tag2.pictures.first.last)
         end
 
         if feed_id

--- a/app/views/feeds/show.xml.builder
+++ b/app/views/feeds/show.xml.builder
@@ -65,7 +65,7 @@ xml.rss "xmlns:atom"=>"http://www.w3.org/2005/Atom", "xmlns:itunes"=>"http://www
         end
         xml.enclosure :length=>episode.length, :type=>"audio/mpeg", :url=>episode.url
 
-        xml.itunes :image, episode.image
+        xml.itunes :image, episode.image_url
         xml.itunes :order, episode.order
         xml.comments episode.comments_url
         xml.source feed_url(:slug => @feed.slug, :format => 'xml')

--- a/db/migrate/20150331023447_change_episode_image_to_attachment.rb
+++ b/db/migrate/20150331023447_change_episode_image_to_attachment.rb
@@ -1,0 +1,6 @@
+class ChangeEpisodeImageToAttachment < ActiveRecord::Migration
+  def change
+    rename_column :episodes, :image, :remote_image_url
+    add_attachment :episodes, :image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150331021452) do
+ActiveRecord::Schema.define(version: 20150331023447) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -48,27 +48,31 @@ ActiveRecord::Schema.define(version: 20150331021452) do
   add_index "admin_users", ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "episodes", force: :cascade do |t|
-    t.string   "title",            limit: 255
-    t.string   "subtitle",         limit: 255
-    t.text     "summary",          limit: 65535
-    t.string   "url",              limit: 255
-    t.string   "length",           limit: 255
-    t.string   "author",           limit: 255
-    t.string   "link",             limit: 255
-    t.string   "guid",             limit: 255
+    t.string   "title",              limit: 255
+    t.string   "subtitle",           limit: 255
+    t.text     "summary",            limit: 65535
+    t.string   "url",                limit: 255
+    t.string   "length",             limit: 255
+    t.string   "author",             limit: 255
+    t.string   "link",               limit: 255
+    t.string   "guid",               limit: 255
     t.datetime "published"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.integer  "feed_id",          limit: 4
-    t.string   "categories",       limit: 255
-    t.string   "mp3_file_name",    limit: 255
-    t.string   "mp3_content_type", limit: 255
-    t.integer  "mp3_file_size",    limit: 4
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.integer  "feed_id",            limit: 4
+    t.string   "categories",         limit: 255
+    t.string   "mp3_file_name",      limit: 255
+    t.string   "mp3_content_type",   limit: 255
+    t.integer  "mp3_file_size",      limit: 4
     t.datetime "mp3_updated_at"
-    t.string   "image",            limit: 255
-    t.string   "order",            limit: 255
-    t.string   "comments_url",     limit: 255
-    t.boolean  "is_published",     limit: 1
+    t.string   "remote_image_url",   limit: 255
+    t.string   "order",              limit: 255
+    t.string   "comments_url",       limit: 255
+    t.boolean  "is_published",       limit: 1
+    t.string   "image_file_name",    limit: 255
+    t.string   "image_content_type", limit: 255
+    t.integer  "image_file_size",    limit: 4
+    t.datetime "image_updated_at"
   end
 
   add_index "episodes", ["feed_id"], name: "index_episodes_on_feed_id", using: :btree


### PR DESCRIPTION
add image attachment functionality. if remote image url is provided - i.e a cdn link - it will override the uploaded image. On mp3 upload, if the mp3 uploaded had an ID3 APIC tag and no image is currently set for the episode, that image is pulled from the tags and uploaded.
